### PR TITLE
JSON syntax validator action

### DIFF
--- a/.github/actions/json-syntax-validator/README.md
+++ b/.github/actions/json-syntax-validator/README.md
@@ -1,0 +1,38 @@
+# json-syntax-validator
+
+# Usage
+## Input parameters
+- `paths` - Required list of comma separated files to validate.
+
+    ```
+    # validate a list of JSON files
+    with:
+        paths: './schema/configuration.json,./app/definitions.json'
+
+    # validate all JSON files in a folder
+    with:
+        paths: './configuration/*.json'
+    ```
+
+## Example
+
+```
+name: Validate JSON files
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  json_validator_job:
+    runs-on: ubuntu-latest
+    name: Validate JSON syntax
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ORGANIZATION_GITHUB_TOKEN }}
+      - uses: shpeliving/gh-shared-workflows/.github/actions/json-syntax-validator@main
+        with:
+          paths: './configuration/*.json'
+```

--- a/.github/actions/json-syntax-validator/action.yml
+++ b/.github/actions/json-syntax-validator/action.yml
@@ -19,7 +19,7 @@ runs:
 
         for file in "${files[@]}"
         do
-          echo "Validating file:" $file
+          echo "Validating file: $file"
           jq empty $file
 
           # if the JSON content of the file is not valid increase the counter

--- a/.github/actions/json-syntax-validator/action.yml
+++ b/.github/actions/json-syntax-validator/action.yml
@@ -1,0 +1,43 @@
+name: JSON Syntax Validator
+description: Validate the syntax of a list of JSON files
+inputs:
+  paths:
+    description: Comma separated list of files
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: |
+        # do not stop the script if an error during file validation occurs
+        set +e
+
+        # split the input paths by commas or new lines
+        files=($(echo ${{ inputs.paths }} | tr "," "\n"))
+
+        # count of the invalid files
+        invalidFiles=0
+
+        for file in "${files[@]}"
+        do
+          echo "Validating file:" $file
+          jq empty $file
+
+          # if the JSON content of the file is not valid increase the counter
+          if [ "$?" -ne 0 ]
+          then
+            invalidFiles=$((invalidFiles+1))
+            echo ">>>Failed"
+          else
+            echo ">>>Valid"
+          fi
+
+          echo -e "\n"
+        done
+
+        # if there are any invalid files throw an error
+        if [ $invalidFiles -gt 0 ]
+        then
+          echo "Number of invalid files:" $invalidFiles
+          exit 1
+        fi
+      shell: bash

--- a/.github/actions/json-syntax-validator/action.yml
+++ b/.github/actions/json-syntax-validator/action.yml
@@ -23,7 +23,7 @@ runs:
           jq empty $file
 
           # if the JSON content of the file is not valid increase the counter
-          if [ "$?" -ne 0 ]
+          if [ $? -ne 0 ]
           then
             invalidFiles=$((invalidFiles+1))
             echo ">>>Failed"

--- a/.github/actions/json-syntax-validator/action.yml
+++ b/.github/actions/json-syntax-validator/action.yml
@@ -15,7 +15,7 @@ runs:
         files=($(echo ${{ inputs.paths }} | tr "," "\n"))
 
         # count of the invalid files
-        invalidFiles=0
+        invalidFilesCount=0
 
         for file in "${files[@]}"
         do

--- a/.github/actions/json-syntax-validator/action.yml
+++ b/.github/actions/json-syntax-validator/action.yml
@@ -25,7 +25,7 @@ runs:
           # if the JSON content of the file is not valid increase the counter
           if [ $? -ne 0 ]
           then
-            invalidFiles=$((invalidFiles+1))
+            invalidFilesCount=$((invalidFilesCount+1))
             echo ">>>Failed"
           else
             echo ">>>Valid"
@@ -35,9 +35,11 @@ runs:
         done
 
         # if there are any invalid files throw an error
-        if [ $invalidFiles -gt 0 ]
+        if [ $invalidFilesCount -gt 0 ]
         then
-          echo "Number of invalid files: $invalidFiles"
+          echo "Number of invalid files: $invalidFilesCount"
           exit 1
         fi
+
+        exit 0
       shell: bash

--- a/.github/actions/json-syntax-validator/action.yml
+++ b/.github/actions/json-syntax-validator/action.yml
@@ -37,7 +37,7 @@ runs:
         # if there are any invalid files throw an error
         if [ $invalidFiles -gt 0 ]
         then
-          echo "Number of invalid files:" $invalidFiles
+          echo "Number of invalid files: $invalidFiles"
           exit 1
         fi
       shell: bash


### PR DESCRIPTION
A GitHub action that expects a list of JSON files and checks if the content is valid. 

We can use it to verify the validity of the [feature toggle schema](https://github.com/shpeliving/showroom-feature-toggles/blob/main/.data/schema.json) and the [survey definitions](https://github.com/shpeliving/survey-service/tree/main/.data/surveys) before we merge them to `main` instead of discovering potential problems when we try to sync them to prod during the release process.

I have added a README with an example usage.