### PR TITLE
Use default dockerfile location when input is not specified

### DIFF
--- a/.github/actions/docker/build/action.yml
+++ b/.github/actions/docker/build/action.yml
@@ -61,7 +61,7 @@ runs:
 
         docker buildx build \
           --build-arg=GITHUB_TOKEN=${{ inputs.github-token }} \
-          -f "${{ inputs.dockerfile }}" \
+          -f "${{ inputs.dockerfile.default }}" \
           -t "${{ steps.info.outputs.full-name }}" \
           "${DOCKER_ARGS[@]}" \
           --load \
@@ -71,7 +71,7 @@ runs:
       run: |
         docker buildx build \
           --build-arg=GITHUB_TOKEN=${{ inputs.github-token }} \
-          -f "${{ inputs.dockerfile }}" \
+          -f "${{ inputs.dockerfile.default }}" \
           --target ${{ steps.info.outputs.test-results-target }} \
           --output type=local,dest=${{ steps.info.outputs.test-results-directory }} \
           "${{ inputs.build-path }}"


### PR DESCRIPTION
Doc: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddefault